### PR TITLE
Removed author page url from blog post

### DIFF
--- a/collections/blog.item
+++ b/collections/blog.item
@@ -26,11 +26,9 @@
     <div class="meta-block">
       {.section author}
         <div class="author">
-          <div class="author__name">
-            <a href="/blog/?author={author.id}" class="boldSansSerif">
-              <span>{author.firstName}</span>
-              <span>{author.lastName}</span>
-            </a>
+          <div class="author__name boldSansSerif">
+            <span>{author.firstName}</span>
+            <span>{author.lastName}</span>
           </div>
           <div class="author__bio sansSerif">
             {author.bio}


### PR DESCRIPTION
As per title, removed hyperlink from author's names as there is already one underneath.