### PR TITLE
adjust pagination buttons text size

### DIFF
--- a/collections/blog.list
+++ b/collections/blog.list
@@ -114,14 +114,14 @@
   <div class="pagination-buttons">
     {.if pagination.prevPage}
       <div class="load-more-wrapper">
-        <a class="prev-page boldSansSerif fontStaticM" href="/blog/{pagination.prevPageUrl}">
+        <a class="prev-page boldSansSerif fontS" href="/blog/{pagination.prevPageUrl}">
           Previous
         </a>
       </div>
     {.end}
     {.if pagination.nextPage}
       <div class="load-more-wrapper">
-        <a class="load-more boldSansSerif fontStaticM" href="/blog/{pagination.nextPageUrl}">
+        <a class="load-more boldSansSerif fontS" href="/blog/{pagination.nextPageUrl}">
           Next page
         </a>
       </div>


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/318)

[Blog] text too large on pagination buttons

### Test plan

- Open the PR deployment branch on the page where both navigation buttons are visible, then change the window size to see that everything is fine now. 😸

### Pre-merge checklist

- [ ] Documentation N/A
- [ ] Unit tests N/A
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [x] Navigate the site using the keyboard only
- [ ] Tester approved
