### PR TITLE
add missing styles for opinion category

### DIFF
--- a/styles/_blog.less
+++ b/styles/_blog.less
@@ -176,11 +176,11 @@ body:not(.button-style-default) .sqs-editable-button, body:not(.button-style-def
   }
 }
 
-.category-list.badger-life li a.badger-life, .category-list.blog li a.blog, .category-list.leadership li a.leadership, .category-list.news li a.news, .category-list.process li a.process, .category-list.strategy li a.strategy, .category-list.technology li a.technology, .category-list.ux-amp-design li a.ux-design {
+.category-list.badger-life li a.badger-life, .category-list.blog li a.blog, .category-list.leadership li a.leadership, .category-list.news li a.news, .category-list.process li a.process, .category-list.strategy li a.strategy, .category-list.technology li a.technology, .category-list.ux-amp-design li a.ux-design, .category-list.opinion li a.opinion {
   .active-category();
 }
 
-.category-list.badger-life li a.all-items, .category-list.blog li a.all-items, .category-list.leadership li a.all-items, .category-list.news li a.all-items, .category-list.process li a.all-items, .category-list.strategy li a.all-items, .category-list.technology li a.all-items, .category-list.ux-amp-design li a.all-items {
+.category-list.badger-life li a.all-items, .category-list.blog li a.all-items, .category-list.leadership li a.all-items, .category-list.news li a.all-items, .category-list.process li a.all-items, .category-list.strategy li a.all-items, .category-list.technology li a.all-items, .category-list.ux-amp-design li a.all-items, .category-list.opinion li a.all-items {
   .non-active-category();
 }
 


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/311)

[Blog] 'OPINION' tag doesn't get highlighted when clicked on

### Test plan

- Open the PR deployment branch and try to navigate to `Opinion` category and see a beautiful button highlight. Yes, unbelievable 🙀 but true.

### Pre-merge checklist

- [ ] Documentation N/A
- [ ] Unit tests N/A
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
