### PR TITLE
Tab navigation issues

### DIFF
--- a/collections/blog.list
+++ b/collections/blog.list
@@ -52,16 +52,6 @@
   {.repeated section items}
     <article class="entry entry--list h-entry grid-hidden {.main-image?} has-main-image {.end}{@|item-classes}" id="article-{id}" label="Blog Post" data-item-id="{id}" data-offset="{addedOn}"{.if pagination.nextPage}{.or} data-last-page{.end}>
 
-    <div class="thumbnail-title-wrapper medium-large-screen">
-      {.main-image?}
-      <div class="excerpt-thumb">
-        <a href="{fullUrl}" class="excerpt-image content-fill">
-          <img src="{assetUrl}?format=500w" />
-        </a>
-      </div>
-      {.end}
-    </div>
-
     <div class="blog-header-excerpt">
       <div class="entry-text">
         <div class="entry-content">
@@ -96,6 +86,16 @@
           {.end}
         </div>
       </div>
+    </div>
+
+    <div class="thumbnail-title-wrapper medium-large-screen">
+      {.main-image?}
+        <div class="excerpt-thumb">
+          <a href="{fullUrl}" class="excerpt-image content-fill">
+            <img src="{assetUrl}?format=500w" />
+          </a>
+        </div>
+      {.end}
     </div>
 
     <div class="thumbnail-title-wrapper small-screen">

--- a/styles/_blog.less
+++ b/styles/_blog.less
@@ -239,8 +239,11 @@ body:not(.button-style-default) .sqs-editable-button, body:not(.button-style-def
     display: block;
   }
 
+  .entry {
+    display: flex;
+  }
+
   .thumbnail-title-wrapper {
-    float: right;
     margin-left: 20px;
   }
 


### PR DESCRIPTION

### Motivation

Fixes: https://github.com/redbadger/website-honestly/issues/198

### Test plan

Try navigating the blog with keyboard and see that right now the image is highlighted after the title of an article.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [ ] Windows 7 IE 11
  - [ ] Windows 10 Edge
  - [ ] Mac OS El Capitan Safari
  - [ ] Mac OS El Capitan Chrome
  - [ ] Mac OS El Capitan Firefox
  - [ ] iOS 9 Safari
  - [ ] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
