### PR TITLE
fix image position on mobile

### DIFF
--- a/collections/blog.list
+++ b/collections/blog.list
@@ -77,6 +77,16 @@
         </h2>
       </header>
 
+      <div class="thumbnail-title-wrapper small-screen">
+        {.main-image?}
+        <div class="excerpt-thumb">
+          <a href="{fullUrl}" class="excerpt-image content-fill">
+            <img src="{assetUrl}?format=500w" />
+          </a>
+        </div>
+        {.end}
+      </div>
+
       <div class="entry-text">
         <div class="entry-content">
           {.excerpt?}
@@ -95,16 +105,6 @@
             <img src="{assetUrl}?format=500w" />
           </a>
         </div>
-      {.end}
-    </div>
-
-    <div class="thumbnail-title-wrapper small-screen">
-      {.main-image?}
-      <div class="excerpt-thumb">
-        <a href="{fullUrl}" class="excerpt-image content-fill">
-          <img src="{assetUrl}?format=500w" />
-        </a>
-      </div>
       {.end}
     </div>
   </article>{.end}


### PR DESCRIPTION
I've talked about that with @Monikamu. This PR moves the image on mobile to lay under the title.

Before:
![image](https://cloud.githubusercontent.com/assets/8601093/22199403/a5fea774-e152-11e6-8ca9-408cc431fd63.png)

After:
![image](https://cloud.githubusercontent.com/assets/8601093/22199499/2820a248-e153-11e6-8d98-0455b8703e48.png)
