### PR TITLE
fix iphone5 horizontal scrolling bug

### DIFF
--- a/styles/_blog.less
+++ b/styles/_blog.less
@@ -1,4 +1,4 @@
-html {
+html, body {
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
### Motivation

- [Related story](https://github.com/redbadger/website-honestly/issues/210)

This fixes iphone5 horizontal scroll bug.

### Test plan

- To test it you have to use physical device or ios simulator. Go to the blog listing page and try to scroll horizontally.

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [x] Listen to the site on a screen reader
  - [x] Navigate the site using the keyboard only
- [ ] Tester approved
