### PR TITLE
fix blog image shift issue

### DIFF
--- a/styles/_blog.less
+++ b/styles/_blog.less
@@ -241,6 +241,7 @@ body:not(.button-style-default) .sqs-editable-button, body:not(.button-style-def
 
   .entry {
     display: flex;
+    justify-content: space-between;
   }
 
   .thumbnail-title-wrapper {


### PR DESCRIPTION
### Motivation

[Related story](https://github.com/redbadger/website-honestly/issues/348)

When blog title is long, featured image is shifted to the right

### Steps to reproduce the bug:

- Open red-badger.com/blog
- Scroll down until you see a blog with a title long enough to be broken into second line
- Observe that featured image is shifted to the right compared to other blogs

### Pre-merge checklist

- [ ] Documentation
- [ ] Unit tests
- [ ] Reviews
  - [ ] Code review
  - [ ] Design review
- [ ] Manual testing
  - [x] Windows 7 IE 11
  - [x] Windows 10 Edge
  - [x] Mac OS El Capitan Safari
  - [x] Mac OS El Capitan Chrome
  - [x] Mac OS El Capitan Firefox
  - [x] iOS 9 Safari
  - [x] Android 6 Chrome
  - [ ] Listen to the site on a screen reader
  - [ ] Navigate the site using the keyboard only
- [ ] Tester approved
