### PR TITLE
Removing GA script as it is injected by Squarespace config now

### DIFF
--- a/site.region
+++ b/site.region
@@ -248,14 +248,5 @@
         </div>
       </div>
     </footer>
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-16654919-1', 'auto');
-    ga('send', 'pageview');
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Squarespace is actually able to inject valid GA script from site settings. This is better since it will also take care of the AMP situation when all extra scripts are skipped.