### PR TITLE
Removing custom Open Graph tags to let SquareSpace correctly take over

### DIFF
--- a/site.region
+++ b/site.region
@@ -10,11 +10,6 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="#212121">
     <meta name="msapplication-TileImage" content="assetsfaviconsmstile-144x144.png">
     <meta property="og:site_name" content="Red Badger blog">
-    <meta property="og:title" content="Red Badger blog" />
-    <meta property="og:description" content="Let’s make things better. We work with you to deliver digital products that make a difference to people." />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image" itemprop="image" content="https://red-badger.com/assets-honestly/social/rb_facebook.png">
     <link rel="apple-touch-icon" href="https://red-badger.com/assets-honestly/favicons/apple-touch-icon-57x57.png" type="image/png" sizes="57x57">
     <link rel="apple-touch-icon" href="https://red-badger.com/assets-honestly/favicons/apple-touch-icon-60x60.png" type="image/png" sizes="60x60">
     <link rel="apple-touch-icon" href="https://red-badger.com/assets-honestly/favicons/apple-touch-icon-72x72.png" type="image/png" sizes="72x72">


### PR DESCRIPTION
Squarespace is actually injecting its own OG tags, and their content is relevant to the pages. To remove double declarations this PR deletes our own custom OG tags from the template.