### PR TITLE
Add blog title and via on twitter share

### DIFF
--- a/collections/blog.item
+++ b/collections/blog.item
@@ -64,7 +64,7 @@
         <ul class="social-links__icons">
             <li>
               <a
-                 href="http://twitter.com/share?url={website.baseUrl}{fullUrl}&via=redbadgerteam&text={title}"
+                 href="https://twitter.com/share?url={website.baseUrl}{fullUrl}&via=redbadgerteam&text={title}"
                  title="Share this article on Twitter"
                  class="social-links__icon"
                  target="_blank"
@@ -74,7 +74,7 @@
             </li>
             <li>
               <a
-                 href="http://www.facebook.com/sharer.php?u={website.baseUrl}{fullUrl}"
+                 href="https://www.facebook.com/sharer.php?u={website.baseUrl}{fullUrl}"
                  title="Share this article on Facebook"
                  class="social-links__icon"
                  target="_blank"

--- a/collections/blog.item
+++ b/collections/blog.item
@@ -64,7 +64,7 @@
         <ul class="social-links__icons">
             <li>
               <a
-                 href="http://twitter.com/share?url={website.baseUrl}{fullUrl}"
+                 href="http://twitter.com/share?url={website.baseUrl}{fullUrl}&via=redbadgerteam&text={title}"
                  title="Share this article on Twitter"
                  class="social-links__icon"
                  target="_blank"


### PR DESCRIPTION
Before, when sharing a blog post on twitter, the tweet came up only with the url to the post. Now it will come up with 

`title` `url` via @redbadgerteam