### PR TITLE
duplicate meta-tags for desktop window size

### DIFF
--- a/blocks/meta-without-author.block
+++ b/blocks/meta-without-author.block
@@ -1,0 +1,43 @@
+{.section categories}
+  <ul class="category-list boldSansSerif">
+    {.repeated section @}
+      <li>
+        <a href="/blog/?category={@|url-encode}">{@}</a>
+      </li>
+    {.end}
+  </ul>
+{.end}
+{.section tags}
+  <ul class="tags-list boldSansSerif">
+    {.repeated section @}
+      <li>
+        <a href="/blog/?tag={@|url-encode}">{@}</a>
+      </li>
+    {.end}
+  </ul>
+{.end}
+<div class="social-links">
+  <div class="social-links__title">Share this article</div>
+  <ul class="social-links__icons">
+    <li>
+      <a
+        href="https://twitter.com/share?url={website.baseUrl}{fullUrl}&via=redbadgerteam&text={title}"
+        title="Share this article on Twitter"
+        class="social-links__icon"
+        target="_blank"
+      >
+        <img src="/assets/twitter_share.svg" title="Twitter">
+      </a>
+    </li>
+    <li>
+      <a
+        href="https://www.facebook.com/sharer.php?u={website.baseUrl}{fullUrl}"
+        title="Share this article on Facebook"
+        class="social-links__icon"
+        target="_blank"
+      >
+        <img src="/assets/facebook_share.svg" title="Facebook">
+      </a>
+    </li>
+  </ul>
+</div>

--- a/collections/blog.item
+++ b/collections/blog.item
@@ -25,49 +25,7 @@
         {.section body}{@}{.end}
       </div>
       <div class="meta-block--repeated">
-        {.section categories}
-          <ul class="category-list boldSansSerif">
-            {.repeated section @}
-              <li>
-                <a href="/blog/?category={@|url-encode}">{@}</a>
-              </li>
-            {.end}
-          </ul>
-        {.end}
-        {.section tags}
-          <ul class="tags-list boldSansSerif">
-            {.repeated section @}
-              <li>
-                <a href="/blog/?tag={@|url-encode}">{@}</a>
-              </li>
-            {.end}
-          </ul>
-        {.end}
-        <div class="social-links">
-          <div class="social-links__title">Share this article</div>
-          <ul class="social-links__icons">
-            <li>
-              <a
-                href="https://twitter.com/share?url={website.baseUrl}{fullUrl}&via=redbadgerteam&text={title}"
-                title="Share this article on Twitter"
-                class="social-links__icon"
-                target="_blank"
-              >
-                <img src="/assets/twitter_share.svg" title="Twitter">
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://www.facebook.com/sharer.php?u={website.baseUrl}{fullUrl}"
-                title="Share this article on Facebook"
-                class="social-links__icon"
-                target="_blank"
-                >
-                <img src="/assets/facebook_share.svg" title="Facebook">
-              </a>
-            </li>
-          </ul>
-        </div>
+        {@|apply meta-without-author.block}
       </div>
     </div>
     <div class="meta-block">
@@ -88,49 +46,7 @@
           </a>
         </div>
       {.end}
-      {.section categories}
-        <ul class="category-list boldSansSerif">
-          {.repeated section @}
-            <li>
-              <a href="/blog/?category={@|url-encode}">{@}</a>
-            </li>
-          {.end}
-        </ul>
-      {.end}
-      {.section tags}
-        <ul class="tags-list boldSansSerif">
-          {.repeated section @}
-            <li>
-              <a href="/blog/?tag={@|url-encode}">{@}</a>
-            </li>
-          {.end}
-        </ul>
-      {.end}
-      <div class="social-links">
-        <div class="social-links__title">Share this article</div>
-        <ul class="social-links__icons">
-            <li>
-              <a
-                 href="https://twitter.com/share?url={website.baseUrl}{fullUrl}&via=redbadgerteam&text={title}"
-                 title="Share this article on Twitter"
-                 class="social-links__icon"
-                 target="_blank"
-                 >
-                <img src="/assets/twitter_share.svg" title="Twitter">
-              </a>
-            </li>
-            <li>
-              <a
-                 href="https://www.facebook.com/sharer.php?u={website.baseUrl}{fullUrl}"
-                 title="Share this article on Facebook"
-                 class="social-links__icon"
-                 target="_blank"
-                 >
-                <img src="/assets/facebook_share.svg" title="Facebook">
-              </a>
-            </li>
-        </ul>
-      </div>
+      {@|apply meta-without-author.block}
     </div>
   </div>
 

--- a/collections/blog.item
+++ b/collections/blog.item
@@ -20,8 +20,55 @@
   {.end}
 
   <div class="body-author__container">
-    <div class="blog-article__body serif">
-      {.section body}{@}{.end}
+    <div class="blog-article__container">
+      <div class="blog-article__body serif">
+        {.section body}{@}{.end}
+      </div>
+      <div class="meta-block--repeated">
+        {.section categories}
+          <ul class="category-list boldSansSerif">
+            {.repeated section @}
+              <li>
+                <a href="/blog/?category={@|url-encode}">{@}</a>
+              </li>
+            {.end}
+          </ul>
+        {.end}
+        {.section tags}
+          <ul class="tags-list boldSansSerif">
+            {.repeated section @}
+              <li>
+                <a href="/blog/?tag={@|url-encode}">{@}</a>
+              </li>
+            {.end}
+          </ul>
+        {.end}
+        <div class="social-links">
+          <div class="social-links__title">Share this article</div>
+          <ul class="social-links__icons">
+            <li>
+              <a
+                href="https://twitter.com/share?url={website.baseUrl}{fullUrl}&via=redbadgerteam&text={title}"
+                title="Share this article on Twitter"
+                class="social-links__icon"
+                target="_blank"
+              >
+                <img src="/assets/twitter_share.svg" title="Twitter">
+              </a>
+            </li>
+            <li>
+              <a
+                href="https://www.facebook.com/sharer.php?u={website.baseUrl}{fullUrl}"
+                title="Share this article on Facebook"
+                class="social-links__icon"
+                target="_blank"
+                >
+                <img src="/assets/facebook_share.svg" title="Facebook">
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
     </div>
     <div class="meta-block">
       {.section author}

--- a/styles/_blog-article.less
+++ b/styles/_blog-article.less
@@ -132,6 +132,10 @@
   padding: 30px 0;
   margin-top: 40px;
 
+  &--repeated {
+    display: none;
+  }
+
   .author {
     border-bottom: 1px solid @linesOnWhite;
     padding-bottom: 20px;
@@ -222,10 +226,12 @@
     margin-bottom: 40px;
   }
 
-  .blog-article__body {
+  .blog-article__container {
     display: inline-block;
     max-width: 675px;
+  }
 
+  .blog-article__body {
     h2, h3 {
       font-size: 30px;
       font-weight: 800;
@@ -244,6 +250,17 @@
     margin-top: 0;
     padding-top: 0;
     border-top: none;
+
+    &--repeated {
+      margin-top: 40px;
+      border-top: 1px solid @linesOnWhite;
+      width: 100%;
+      display: inline-block;
+
+      .category-list {
+        margin-bottom: -10px;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
Duplicate blog CTAs at bottom of page (categories, tags, social sharing links)

### This was added on desktop
![image](https://cloud.githubusercontent.com/assets/8601093/23404677/11a2bd90-fdae-11e6-8511-7ac4ea656c14.png)

### This is what we have already while viewing the page on mobile.
![image](https://cloud.githubusercontent.com/assets/8601093/23404745/72abc19a-fdae-11e6-9497-43baa56d6163.png)

