### PR TITLE
Add default styling for source-code

### DIFF
--- a/styles/_blog-article.less
+++ b/styles/_blog-article.less
@@ -295,3 +295,9 @@
 .social-links__icon {
   margin-right: 20px;
 }
+
+.source-code {
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 1.5em;
+}


### PR DESCRIPTION
This adds some very simple styling for code snippets (it works fine with sq-space's code blocks). 

I'm wasn't sure if we have if have any on-brand mono fonts, so I'm defaulting to whatever's available in the browser. `14px` seemed like a good size because snippets wrap easily.

I guess this should go in some way into the RB style guide but not sure where/how that's done 🤔 