### PR TITLE
Enable greyscale bar on blog

### DIFF
--- a/scripts/greyscale.js
+++ b/scripts/greyscale.js
@@ -87,5 +87,5 @@ function initGreyscaleModeBar() {
 }
 
 // Uncomment this to enable the a11y-day bar
-// initGreyscaleModeBar();
+initGreyscaleModeBar();
 


### PR DESCRIPTION
Enable greyscale bar for a11y day. 

Also needs to be done for the main site https://github.com/redbadger/website-honestly/compare/enable-greyscale-bar